### PR TITLE
extra_cxxflags fixed and extra_include_dirs added

### DIFF
--- a/sip/configure.py
+++ b/sip/configure.py
@@ -92,7 +92,11 @@ if platform.system() == 'Windows':
     else:
         makefile.extra_lib_dirs = ['..\\build\\msvc\\9.0\\libprocesslib\\Release']
 else:
-    makefile.extra_cxxflags = ['-pthread','-I../core/include','-I../tasks/include','-I' + numpy.get_include()]
+    makefile.extra_cxxflags = ['-pthread']
+    makefile.extra_include_dirs = ['../core/include',
+                                   '../tasks/include',
+                                   config.sip_inc_dir,
+                                   numpy.get_include()]
     makefile.extra_libs = ['pthread','processlib']
     makefile.extra_lib_dirs = ['../build']
 


### PR DESCRIPTION
Use extra_include_dirs instead of adding -I flags in extra_cxxflags
Add sip_inc_dir from sip config

These changes fixes a problem when working with different sip versions